### PR TITLE
Fix code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/core/regex.js
+++ b/src/core/regex.js
@@ -5,7 +5,7 @@ let kanji =
   "[uFF00-uFFEF]|[u4E00-u9FAF]|[u2605-u2606]|[u2190-u2195]|u203B|" +
   "[u2010u2015u2018u2019u2025u2026u201Cu201Du2225u2260]|" +
   "[u0391-u0451]|[u00A7u00A8u00B1u00B4u00D7u00F7])+";
-kanji = kanji.replace(/u/g, "\\u");
+kanji = kanji.replace(/\\/g, "\\\\").replace(/u/g, "\\u");
 
 const byte = `(?:(?![A-Z0-9 $%*+\\-./:]|${kanji})(?:.|[\r\n]))+`;
 


### PR DESCRIPTION
Fixes [https://github.com/chrisllontop/qrex/security/code-scanning/1](https://github.com/chrisllontop/qrex/security/code-scanning/1)

To fix the problem, we need to ensure that all occurrences of the character 'u' are replaced with "\\u" and that any existing backslashes in the `kanji` string are properly escaped. This can be achieved by first escaping all backslashes and then replacing 'u' with "\\u" using regular expressions with the global flag.

1. Escape all backslashes in the `kanji` string by replacing each backslash with a double backslash.
2. Replace all occurrences of the character 'u' with "\\u".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
