### PR TITLE
delete variable cb in rendererPng class and modify test 

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@rspack/cli": "^1.1.0",
     "@rspack/core": "^1.1.0",
     "@types/node": "^22.9.1",
+    "@types/pngjs": "^6.0.5",
     "@vitest/coverage-istanbul": "2.1.4",
     "@vitest/coverage-v8": "^2.1.5",
     "babel-loader": "^9.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@types/node':
         specifier: ^22.9.1
         version: 22.9.1
+      '@types/pngjs':
+        specifier: ^6.0.5
+        version: 6.0.5
       '@vitest/coverage-istanbul':
         specifier: 2.1.4
         version: 2.1.4(vitest@2.1.4(@types/node@22.9.1)(@vitest/ui@2.1.4)(terser@5.36.0))
@@ -1086,6 +1089,9 @@ packages:
 
   '@types/node@22.9.1':
     resolution: {integrity: sha512-p8Yy/8sw1caA8CdRIQBG5tiLHmxtQKObCijiAa9Ez+d4+PRffM4054xbju0msf+cvhJpnFEeNjxmVT/0ipktrg==}
+
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
 
   '@types/qs@6.9.17':
     resolution: {integrity: sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==}
@@ -4142,6 +4148,10 @@ snapshots:
   '@types/node@22.9.1':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 22.9.1
 
   '@types/qs@6.9.17': {}
 

--- a/src/qrex.ts
+++ b/src/qrex.ts
@@ -72,6 +72,6 @@ export class QRex extends QRexBase {
     const renderer = this.getRendererFromType("png") as RendererPng;
     const renderToFileStream = renderer.renderToFileStream.bind(null, stream);
 
-    this.render(renderToFileStream);
+    return this.render(renderToFileStream);
   }
 }

--- a/src/qrex.ts
+++ b/src/qrex.ts
@@ -1,10 +1,10 @@
+import type { WriteStream } from "node:fs";
 import { QRexBase } from "./qrex.base";
 import { RendererPng } from "./renderer/png";
 import { RendererSvg } from "./renderer/svg";
 import { RendererTerminal } from "./renderer/terminal";
 import { RendererUtf8 } from "./renderer/utf8";
 import type { RendererType } from "./types/qrex.type";
-import type { Stream } from "node:stream";
 
 export class QRex extends QRexBase {
   private getTypeFromFilename(path: string): RendererType {
@@ -69,7 +69,7 @@ export class QRex extends QRexBase {
     throw new Error("File is not supported for this renderer");
   }
 
-  public toFileStream(stream: Stream) {
+  public toFileStream(stream: WriteStream) {
     const renderer = this.getRendererFromType("png") as RendererPng;
     const renderToFileStream = renderer.renderToFileStream.bind(renderer, stream);
 

--- a/src/renderer/png.ts
+++ b/src/renderer/png.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import type { WriteStream } from "node:fs";
-import { PNG } from "pngjs/browser";
+import { PNG } from "pngjs";
 import type { QRData, QRexOptions } from "../types/qrex.type";
 import { RendererUtils } from "./utils";
 
@@ -12,9 +12,9 @@ export class RendererPng {
 
     pngOpts.width = size;
     pngOpts.height = size;
-    
+
     const pngImage = new PNG(pngOpts);
-    
+
     RendererUtils.qrToImageData(pngImage.data, qrData, opts);
 
     return pngImage;
@@ -28,15 +28,15 @@ export class RendererPng {
       png.on("data", (chunk) => {
         chunks.push(chunk);
       });
-  
+
       png.on("end", () => {
         resolve(Buffer.concat(chunks));
       });
-  
+
       png.on("error", (err) => {
         reject(err);
       });
-  
+
       png.pack();
     });
   }

--- a/src/renderer/png.ts
+++ b/src/renderer/png.ts
@@ -62,7 +62,7 @@ export class RendererPng {
 
   public renderToFileStream(stream, qrData: QRData, options?: QRexOptions) {
     const png = this.render(qrData, options);
-    png.pack().pipe(stream);
+    return png.pack().pipe(stream);
   }
 
   public renderToDataURL(qrData: QRData, options?: QRexOptions, cb?) {

--- a/src/renderer/png.ts
+++ b/src/renderer/png.ts
@@ -48,7 +48,7 @@ export class RendererPng {
 
   public renderToFileStream(stream: WriteStream, qrData: QRData, options?: QRexOptions) {
     const png = this.render(qrData, options);
-    return png.pack().pipe(stream);
+    png.pack().pipe(stream);
   }
 
   public async renderToDataURL(qrData: QRData, options?: QRexOptions) {

--- a/tests/unit/renderer/png.test.ts
+++ b/tests/unit/renderer/png.test.ts
@@ -64,24 +64,15 @@ describe("PNG renderToDataURL", () => {
   });
 
   it("should not generate errors with only qrData param and return a string", async () => {
-    const url = await new Promise((resolve, reject) => {
-      const renderer: RendererPng = new RendererPng();
-      renderer.renderToDataURL(sampleQrData, (err, url) => {
-        if (err) reject(err);
-        else resolve(url);
-      });
-    });
+    const renderer: RendererPng = new RendererPng();
+    const url = await renderer.renderToDataURL(sampleQrData);
     expect(url).toBeTypeOf("string");
   });
 
   it("should not generate errors with options param and return a valid data URL", async () => {
-    const url = await new Promise((resolve, reject) => {
-      const renderer: RendererPng = new RendererPng();
-      renderer.renderToDataURL(sampleQrData, { margin: 10, scale: 1 }, (err, url) => {
-        if (err) reject(err);
-        else resolve(url);
-      });
-    });
+    const renderer: RendererPng = new RendererPng();
+
+    const url = await renderer.renderToDataURL(sampleQrData, { margin: 10, scale: 1 });
 
     expect(url).toBeTypeOf("string");
     expect(url.split(",")[0]).toBe("data:image/png;base64");
@@ -100,18 +91,8 @@ describe("PNG renderToFile", () => {
   it("should not generate errors with only qrData param and save file with correct file name", async () => {
     const fsStub = vi.spyOn(fs, "createWriteStream").mockReturnValue(new StreamMock() as unknown as fs.WriteStream);
 
-    await new Promise<void>((resolve, reject) => {
-      const renderer: RendererPng = new RendererPng();
-      renderer.renderToFile(fileName, sampleQrData, { margin: 10, scale: 1 }, (err) => {
-        try {
-          expect(err).toBeFalsy();
-
-          resolve();
-        } catch (e) {
-          reject(e);
-        }
-      });
-    });
+    const renderer: RendererPng = new RendererPng();
+    await renderer.renderToFile(fileName, sampleQrData, { margin: 10, scale: 1 });
 
     fsStub.mockRestore();
   });
@@ -121,16 +102,7 @@ describe("PNG renderToFile", () => {
 
     const renderer: RendererPng = new RendererPng();
 
-    await new Promise<void>((resolve, reject) => {
-      renderer.renderToFile(fileName, sampleQrData, { margin: 10, scale: 1 }, (err) => {
-        try {
-          expect(err).toBeFalsy();
-          resolve();
-        } catch (e) {
-          reject(e);
-        }
-      });
-    });
+    await renderer.renderToFile(fileName, sampleQrData, { margin: 10, scale: 1 });
 
     fsStub.mockRestore();
   });
@@ -138,17 +110,8 @@ describe("PNG renderToFile", () => {
   it("should fail if error occurs during save", async () => {
     const fsStub = vi.spyOn(fs, "createWriteStream").mockReturnValue(new StreamMock().forceErrorOnWrite());
 
-    await new Promise((resolve, reject) => {
-      const renderer: RendererPng = new RendererPng();
-      renderer.renderToFile(fileName, sampleQrData, { margin: 10, scale: 1 }, (err) => {
-        try {
-          expect(err).toBeUndefined();
-          resolve();
-        } catch (e) {
-          reject(e);
-        }
-      });
-    });
+    const renderer: RendererPng = new RendererPng();
+    await renderer.renderToFile(fileName, sampleQrData, { margin: 10, scale: 1 });
 
     fsStub.mockRestore();
   });


### PR DESCRIPTION
In this pr I am eliminating the use of callbacks in the functions of the renderer png class, also the way of generating the buffer and adapting the tests to these changes